### PR TITLE
Configure strict JWT validation

### DIFF
--- a/RedRiver.BookQuotes.Api/Controllers/AuthController.cs
+++ b/RedRiver.BookQuotes.Api/Controllers/AuthController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using RedRiver.BookQuotes.Api.Data;
 using RedRiver.BookQuotes.Api.Dtos;
@@ -29,6 +30,7 @@ namespace RedRiver.BookQuotes.Api.Controllers
         /// Registers a new user by hashing and salting their password
         /// before saving the credentials to the database.
         /// </summary>
+        [AllowAnonymous]
         [HttpPost("register")]
         public async Task<IActionResult> Register([FromBody] RegisterRequestDto request)
         {
@@ -60,6 +62,7 @@ namespace RedRiver.BookQuotes.Api.Controllers
         /// <summary>
         /// Authenticates the user and issues a JWT upon successful login.
         /// </summary>
+        [AllowAnonymous]
         [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] LoginRequestDto request)
         {


### PR DESCRIPTION
1. Added JWT validation with issuer, audience, lifetime, and signing key checks.
2. Used the standard JWT Bearer scheme for safer setup.
3. Added strict token expiration with ClockSkew = TimeSpan.Zero.
4. Added [AllowAnonymous] to login and register so they stay public.
5. Added early check for missing JWT key in configuration.
6. Confirmed correct order of UseAuthentication() and UseAuthorization().